### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action/fetchaction.php
+++ b/action/fetchaction.php
@@ -22,7 +22,7 @@ class action_plugin_templateconfhelper_fetchaction extends DokuWiki_Action_Plugi
     );
   }
 
-  function register(&$controller) {/*{{{*/
+  function register(Doku_Event_Handler $controller) {/*{{{*/
 
       $controller->register_hook('FETCH_MEDIA_STATUS', 'BEFORE', $this, 'fetch_action' );
 

--- a/action/templateaction.php
+++ b/action/templateaction.php
@@ -23,7 +23,7 @@ class action_plugin_templateconfhelper_templateaction extends DokuWiki_Action_Pl
     );
   }
 
-  function register(&$controller) {/*{{{*/
+  function register(Doku_Event_Handler $controller) {/*{{{*/
 
       $controller->register_hook('ACTION_ACT_PREPROCESS', 'BEFORE',  $this, 'template_action' );
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
